### PR TITLE
chore: Upgrade nearcore dependencies to 1.31.0-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.1.19
+
+* Upgrade Indexer Framework to be based on [nearcore 1.31.0-rc.4](https://github.com/near/nearcore/commit/f709cdc89adfa0594df5ac20212e75402a1b862e)
+
+### Heads-up
+
+Some updates on the `nearcore` side affected the Indexer Framework:
+- `near_client` calls require the usage of `near_o11y::WithSpanContextExt`. Thus we depend on `near-o11y` explicitly since this version
+- `init_configs` function has been extended with a parameter `download_records_url: Option<&str>`. Thus `init` command of the Lake Indexer has been extended with the parameter `donwload_genesis_records_url`
+- `IndexerConfig` requires new parameter `validate_genesis: bool` so the `run` command has been extended with the key `--validate-genesis`
+
 ## 0.1.18
 
 * Upgrade Indexer Framework to be based on [nearcore 1.30.1](https://github.com/near/nearcore/commit/e2bf95c0737f7e80c70e77ae82b439342119148a)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,9 +60,9 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.0.4"
+version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5885cb81a0d4d0d322864bea1bb6c2a8144626b4fdc625d4c51eba197e7797a"
+checksum = "0c83abf9903e1f0ad9973cc4f7b9767fd5a03a583f51a5b7a339e07987cd2724"
 dependencies = [
  "actix-codec",
  "actix-rt",
@@ -85,13 +85,13 @@ dependencies = [
  "itoa",
  "language-tags",
  "local-channel",
- "log",
  "mime",
  "percent-encoding",
  "pin-project-lite",
  "rand 0.8.5",
- "sha-1",
+ "sha1",
  "smallvec",
+ "tracing",
  "zstd",
 ]
 
@@ -317,6 +317,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1485d4d2cc45e7b201ee3767015c96faa5904387c9d87c6efdd0fb511f12d305"
 
 [[package]]
+name = "arbitrary"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c38b6b6b79f671c25e1a3e785b7b82d7562ffc9cd3efdc98627e5668a2472490"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,9 +383,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.53"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
+checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -392,15 +401,6 @@ dependencies = [
  "hermit-abi",
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "autocfg"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
-dependencies = [
- "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -772,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.59.2"
+version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
+checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -1121,12 +1121,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "conqueue"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac4306c796b95d3964b94fa65018a57daee08b45a54b86a4f64910426427b66"
-
-[[package]]
 name = "console"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,7 +1341,7 @@ version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "cfg-if 1.0.0",
  "crossbeam-utils",
  "lazy_static",
@@ -1460,10 +1454,21 @@ dependencies = [
 [[package]]
 name = "delay-detector"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
  "cpu-time",
  "tracing",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98e23c06c035dac87bd802d98f368df73a7f2cb05a66ffbd1f377e821fac4af9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2000,6 +2005,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "http"
@@ -2144,7 +2152,7 @@ version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "hashbrown 0.11.2",
  "serde",
 ]
@@ -2158,6 +2166,7 @@ dependencies = [
  "console",
  "lazy_static",
  "number_prefix",
+ "rayon",
  "regex",
 ]
 
@@ -2260,9 +2269,9 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.6.1+6.28.2"
+version = "0.8.0+7.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc587013734dadb7cf23468e531aa120788b87243648be42e2d3a072186291"
+checksum = "611804e4666a25136fcc5f8cf425ab4d26c7f74ea245ffe92ea23b85b6420b5d"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -2330,7 +2339,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "scopeguard",
  "serde",
 ]
@@ -2454,7 +2463,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
 ]
 
 [[package]]
@@ -2523,8 +2532,9 @@ dependencies = [
 [[package]]
 name = "near-account-id"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
+ "arbitrary",
  "borsh",
  "serde",
 ]
@@ -2532,7 +2542,7 @@ dependencies = [
 [[package]]
 name = "near-cache"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
  "lru",
 ]
@@ -2540,10 +2550,11 @@ dependencies = [
 [[package]]
 name = "near-chain"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
  "actix",
  "ansi_term",
+ "assert_matches",
  "borsh",
  "chrono",
  "crossbeam-channel",
@@ -2563,7 +2574,8 @@ dependencies = [
  "near-store",
  "num-rational",
  "once_cell",
- "rand 0.7.3",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rayon",
  "strum",
  "thiserror",
@@ -2573,7 +2585,7 @@ dependencies = [
 [[package]]
 name = "near-chain-configs"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2591,7 +2603,7 @@ dependencies = [
 [[package]]
 name = "near-chain-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
  "chrono",
  "near-crypto",
@@ -2603,7 +2615,7 @@ dependencies = [
 [[package]]
 name = "near-chunks"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
  "actix",
  "borsh",
@@ -2614,13 +2626,12 @@ dependencies = [
  "near-chunks-primitives",
  "near-crypto",
  "near-network",
- "near-network-primitives",
  "near-o11y",
  "near-pool",
  "near-primitives",
  "near-store",
  "once_cell",
- "rand 0.7.3",
+ "rand 0.8.5",
  "reed-solomon-erasure",
  "tracing",
 ]
@@ -2628,7 +2639,7 @@ dependencies = [
 [[package]]
 name = "near-chunks-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
  "near-chain-primitives",
  "near-primitives",
@@ -2637,11 +2648,12 @@ dependencies = [
 [[package]]
 name = "near-client"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
  "actix",
  "actix-rt",
  "ansi_term",
+ "async-trait",
  "borsh",
  "chrono",
  "delay-detector",
@@ -2654,8 +2666,9 @@ dependencies = [
  "near-chunks",
  "near-client-primitives",
  "near-crypto",
+ "near-dyn-configs",
+ "near-epoch-manager",
  "near-network",
- "near-network-primitives",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
@@ -2665,7 +2678,7 @@ dependencies = [
  "near-telemetry",
  "num-rational",
  "once_cell",
- "rand 0.7.3",
+ "rand 0.8.5",
  "reed-solomon-erasure",
  "serde_json",
  "strum",
@@ -2678,7 +2691,7 @@ dependencies = [
 [[package]]
 name = "near-client-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
  "actix",
  "chrono",
@@ -2686,7 +2699,6 @@ dependencies = [
  "near-chain-primitives",
  "near-chunks-primitives",
  "near-crypto",
- "near-network-primitives",
  "near-primitives",
  "once_cell",
  "serde",
@@ -2698,9 +2710,8 @@ dependencies = [
 [[package]]
 name = "near-crypto"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
- "arrayref",
  "blake2",
  "borsh",
  "bs58",
@@ -2709,6 +2720,7 @@ dependencies = [
  "derive_more",
  "ed25519-dalek",
  "near-account-id",
+ "near-stdx",
  "once_cell",
  "primitive-types",
  "rand 0.7.3",
@@ -2720,9 +2732,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "near-dyn-configs"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+dependencies = [
+ "near-o11y",
+ "once_cell",
+ "prometheus",
+]
+
+[[package]]
 name = "near-epoch-manager"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
  "borsh",
  "near-cache",
@@ -2733,8 +2755,8 @@ dependencies = [
  "near-store",
  "num-rational",
  "primitive-types",
- "rand 0.6.5",
- "rand 0.7.3",
+ "rand 0.8.5",
+ "rand_hc 0.3.1",
  "serde_json",
  "smart-default",
  "tracing",
@@ -2743,7 +2765,7 @@ dependencies = [
 [[package]]
 name = "near-indexer"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
  "actix",
  "anyhow",
@@ -2752,6 +2774,7 @@ dependencies = [
  "near-chain-configs",
  "near-client",
  "near-crypto",
+ "near-dyn-configs",
  "near-indexer-primitives",
  "near-o11y",
  "near-primitives",
@@ -2769,7 +2792,7 @@ dependencies = [
 [[package]]
 name = "near-indexer-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
  "near-primitives",
  "serde",
@@ -2779,11 +2802,12 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
  "actix",
  "actix-cors",
  "actix-web",
+ "bs58",
  "easy-ext",
  "futures",
  "near-chain-configs",
@@ -2792,7 +2816,6 @@ dependencies = [
  "near-jsonrpc-client",
  "near-jsonrpc-primitives",
  "near-network",
- "near-network-primitives",
  "near-o11y",
  "near-primitives",
  "near-rpc-error-macro",
@@ -2807,7 +2830,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
  "actix-http",
  "awc",
@@ -2821,8 +2844,9 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
+ "arbitrary",
  "near-chain-configs",
  "near-client-primitives",
  "near-crypto",
@@ -2835,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "near-lake"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "actix",
  "anyhow",
@@ -2851,6 +2875,7 @@ dependencies = [
  "near-client",
  "near-indexer",
  "near-indexer-primitives",
+ "near-o11y",
  "openssl-probe",
  "serde",
  "serde_json",
@@ -2863,7 +2888,7 @@ dependencies = [
 [[package]]
 name = "near-mainnet-res"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
@@ -2874,17 +2899,17 @@ dependencies = [
 [[package]]
 name = "near-network"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
  "actix",
  "anyhow",
  "arc-swap",
  "assert_matches",
+ "async-trait",
  "borsh",
  "bytes",
  "bytesize",
  "chrono",
- "conqueue",
  "crossbeam-channel",
  "delay-detector",
  "futures",
@@ -2893,7 +2918,6 @@ dependencies = [
  "itertools",
  "lru",
  "near-crypto",
- "near-network-primitives",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
@@ -2905,68 +2929,49 @@ dependencies = [
  "parking_lot 0.12.1",
  "protobuf 3.0.2",
  "protobuf-codegen",
- "rand 0.7.3",
- "rand_xorshift 0.2.0",
+ "rand 0.8.5",
+ "rand_xorshift",
  "rayon",
  "serde",
  "smart-default",
  "strum",
  "thiserror",
+ "time 0.3.9",
  "tokio",
  "tokio-stream",
  "tokio-util 0.7.2",
- "tracing",
- "tracing-opentelemetry",
-]
-
-[[package]]
-name = "near-network-primitives"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
-dependencies = [
- "actix",
- "anyhow",
- "borsh",
- "chrono",
- "near-crypto",
- "near-primitives",
- "once_cell",
- "opentelemetry",
- "serde",
- "strum",
- "thiserror",
- "time 0.3.9",
- "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "near-o11y"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
+ "actix",
  "atty",
- "backtrace",
  "clap",
+ "near-crypto",
+ "near-primitives-core",
  "once_cell",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "prometheus",
+ "serde",
  "strum",
  "thiserror",
  "tokio",
  "tracing",
  "tracing-appender",
  "tracing-opentelemetry",
- "tracing-serde",
  "tracing-subscriber 0.3.15",
 ]
 
 [[package]]
 name = "near-performance-metrics"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
  "actix",
  "bitflags",
@@ -2983,7 +2988,7 @@ dependencies = [
 [[package]]
 name = "near-performance-metrics-macros"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
  "quote",
  "syn",
@@ -2992,54 +2997,60 @@ dependencies = [
 [[package]]
 name = "near-pool"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
  "borsh",
  "near-crypto",
  "near-o11y",
  "near-primitives",
  "once_cell",
- "rand 0.7.3",
+ "rand 0.8.5",
 ]
 
 [[package]]
 name = "near-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
+ "arbitrary",
  "borsh",
- "byteorder",
  "bytesize",
  "cfg-if 1.0.0",
  "chrono",
  "derive_more",
  "easy-ext",
+ "enum-map",
  "hex",
  "near-crypto",
+ "near-o11y",
  "near-primitives-core",
  "near-rpc-error-macro",
+ "near-stdx",
  "near-vm-errors",
  "num-rational",
  "once_cell",
  "primitive-types",
- "rand 0.7.3",
+ "rand 0.8.5",
  "reed-solomon-erasure",
  "serde",
  "serde_json",
  "smart-default",
  "strum",
  "thiserror",
+ "tracing",
 ]
 
 [[package]]
 name = "near-primitives-core"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
+ "arbitrary",
  "base64",
  "borsh",
  "bs58",
  "derive_more",
+ "enum-map",
  "near-account-id",
  "num-rational",
  "serde",
@@ -3051,7 +3062,7 @@ dependencies = [
 [[package]]
 name = "near-rosetta-rpc"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
  "actix",
  "actix-cors",
@@ -3067,6 +3078,7 @@ dependencies = [
  "near-client-primitives",
  "near-crypto",
  "near-network",
+ "near-o11y",
  "near-primitives",
  "paperclip",
  "serde",
@@ -3079,7 +3091,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-core"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
  "quote",
  "serde",
@@ -3089,8 +3101,9 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-macro"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
+ "fs2",
  "near-rpc-error-core",
  "serde",
  "syn",
@@ -3099,12 +3112,17 @@ dependencies = [
 [[package]]
 name = "near-stable-hasher"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+
+[[package]]
+name = "near-stdx"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 
 [[package]]
 name = "near-store"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3120,9 +3138,10 @@ dependencies = [
  "near-crypto",
  "near-o11y",
  "near-primitives",
+ "near-stdx",
  "num_cpus",
  "once_cell",
- "rand 0.7.3",
+ "rand 0.8.5",
  "rlimit",
  "rocksdb",
  "serde",
@@ -3136,7 +3155,7 @@ dependencies = [
 [[package]]
 name = "near-telemetry"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
  "actix",
  "awc",
@@ -3155,22 +3174,22 @@ dependencies = [
 [[package]]
 name = "near-vm-errors"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
  "borsh",
  "near-account-id",
  "near-rpc-error-macro",
  "serde",
  "strum",
+ "thiserror",
 ]
 
 [[package]]
 name = "near-vm-logic"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
  "borsh",
- "bs58",
  "byteorder",
  "ed25519-dalek",
  "near-account-id",
@@ -3178,10 +3197,11 @@ dependencies = [
  "near-o11y",
  "near-primitives",
  "near-primitives-core",
+ "near-stdx",
  "near-vm-errors",
  "ripemd",
  "serde",
- "sha2 0.9.9",
+ "sha2 0.10.2",
  "sha3",
  "zeropool-bn",
 ]
@@ -3189,7 +3209,7 @@ dependencies = [
 [[package]]
 name = "near-vm-runner"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3220,8 +3240,8 @@ dependencies = [
 
 [[package]]
 name = "nearcore"
-version = "1.30.1"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3244,11 +3264,11 @@ dependencies = [
  "near-client",
  "near-client-primitives",
  "near-crypto",
+ "near-dyn-configs",
  "near-epoch-manager",
  "near-jsonrpc",
  "near-mainnet-res",
  "near-network",
- "near-network-primitives",
  "near-o11y",
  "near-performance-metrics",
  "near-pool",
@@ -3260,7 +3280,7 @@ dependencies = [
  "node-runtime",
  "num-rational",
  "once_cell",
- "rand 0.7.3",
+ "rand 0.8.5",
  "rayon",
  "rlimit",
  "serde",
@@ -3291,7 +3311,7 @@ dependencies = [
 [[package]]
 name = "node-runtime"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=e2bf95c0737f7e80c70e77ae82b439342119148a#e2bf95c0737f7e80c70e77ae82b439342119148a"
+source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
 dependencies = [
  "borsh",
  "byteorder",
@@ -3308,7 +3328,7 @@ dependencies = [
  "num-rational",
  "num-traits",
  "once_cell",
- "rand 0.7.3",
+ "rand 0.8.5",
  "rayon",
  "serde",
  "serde_json",
@@ -3342,7 +3362,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -3353,7 +3373,7 @@ version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "num-traits",
 ]
 
@@ -3363,7 +3383,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -3376,7 +3396,7 @@ version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
 ]
 
 [[package]]
@@ -3475,7 +3495,7 @@ version = "0.9.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "cc",
  "libc",
  "openssl-src",
@@ -3798,18 +3818,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.38"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9027b48e9d4c9175fa2218adf3557f91c1137021739951d4932f5f8268ac48aa"
+checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "prometheus"
-version = "0.13.1"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cface98dfa6d645ea4c789839f176e4b072265d085bfcc48eaa8d137f58d3c39"
+checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
 dependencies = [
  "cfg-if 1.0.0",
  "fnv",
@@ -3981,24 +4001,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-dependencies = [
- "autocfg 0.1.8",
- "libc",
- "rand_chacha 0.1.1",
- "rand_core 0.4.2",
- "rand_hc 0.1.0",
- "rand_isaac",
- "rand_jitter",
- "rand_pcg",
- "rand_xorshift 0.1.1",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -4023,16 +4025,6 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-dependencies = [
- "autocfg 0.1.8",
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
@@ -4050,21 +4042,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.6.3",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -4086,15 +4063,6 @@ dependencies = [
 
 [[package]]
 name = "rand_hc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
@@ -4103,51 +4071,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_isaac"
-version = "0.1.1"
+name = "rand_hc"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-dependencies = [
- "libc",
- "rand_core 0.4.2",
- "winapi",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-dependencies = [
- "autocfg 0.1.8",
- "rand_core 0.4.2",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
 name = "rand_xorshift"
-version = "0.1.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
-dependencies = [
- "rand_core 0.5.1",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -4165,7 +4103,7 @@ version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "crossbeam-deque",
  "either",
  "rayon-core",
@@ -4358,9 +4296,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "620f4129485ff1a7128d184bc687470c21c7951b64779ebc9cfdad3dcd920290"
+checksum = "7e9562ea1d70c0cc63a34a22d977753b50cca91cc6b6527750463bd5dd8697bc"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -4487,9 +4425,9 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "secp256k1"
-version = "0.24.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7649a0b3ffb32636e60c7ce0d70511eda9c52c658cd0634e194d5a19943aeff"
+checksum = "d9512ffd81e3a3503ed401f79c33168b9148c75038956039166cd750eaa037c3"
 dependencies = [
  "rand 0.8.5",
  "secp256k1-sys",
@@ -4643,10 +4581,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.10.0"
+name = "sha1"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
+checksum = "006769ba83e921b3085caa8334186b00cf92b4cb1a6cf4632fbccc8eff5c7549"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -4820,13 +4758,13 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.94"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07e33e919ebcd69113d5be0e4d70c5707004ff45188910106854f38b960df4a"
+checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -4938,9 +4876,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.4.3+5.2.1-patched.2"
+version = "0.5.2+5.3.0-patched"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1792ccb507d955b46af42c123ea8863668fae24d03721e40cad6a41773dbb49"
+checksum = "ec45c14da997d0925c7835883e4d5c181f196fa142f8c19d7643d1e9af2592c3"
 dependencies = [
  "cc",
  "fs_extra",
@@ -5225,9 +5163,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -5347,6 +5285,12 @@ name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
 
 [[package]]
 name = "unicode-normalization"
@@ -6024,18 +5968,18 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.10.2+zstd.1.5.2"
+version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4a6bd64f22b5e3e94b4e238669ff9f10815c27a5180108b849d24174a83847"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "4.1.6+zstd.1.5.2"
+version = "5.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b61c51bb270702d6167b8ce67340d2754b088d0c091b06e593aa772c3ee9bb"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
 dependencies = [
  "libc",
  "zstd-sys",
@@ -6043,9 +5987,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "1.6.3+zstd.1.5.2"
+version = "2.0.1+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc49afa5c8d634e75761feda8c592051e7eeb4683ba827211eb0d731d3402ea8"
+checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "near-lake"
-version = "0.1.18"
+version = "0.1.19"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
-rust-version = "1.62.1"
+rust-version = "1.65.0"
 
 [dependencies]
 actix = "0.13.0"
@@ -25,6 +25,7 @@ tokio-stream = { version = "0.1" }
 tracing = "0.1.34"
 tracing-subscriber = "0.2.4"
 
-near-indexer = { git = "https://github.com/near/nearcore", rev = "e2bf95c0737f7e80c70e77ae82b439342119148a" }
-near-indexer-primitives = { git = "https://github.com/near/nearcore", rev = "e2bf95c0737f7e80c70e77ae82b439342119148a" }
-near-client = { git = "https://github.com/near/nearcore", rev = "e2bf95c0737f7e80c70e77ae82b439342119148a" }
+near-indexer = { git = "https://github.com/near/nearcore", rev = "f709cdc89adfa0594df5ac20212e75402a1b862e" }
+near-indexer-primitives = { git = "https://github.com/near/nearcore", rev = "f709cdc89adfa0594df5ac20212e75402a1b862e" }
+near-client = { git = "https://github.com/near/nearcore", rev = "f709cdc89adfa0594df5ac20212e75402a1b862e" }
+near-o11y = { git = "https://github.com/near/nearcore", rev = "f709cdc89adfa0594df5ac20212e75402a1b862e" }

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -24,7 +24,7 @@ pub(crate) enum SubCommand {
     /// Run NEAR Indexer Example. Start observe the network
     Run(RunArgs),
     /// Initialize necessary configs
-    Init(InitConfigArgs),
+    Init(Box<InitConfigArgs>), // clippy suggestion: consider boxing the large fields to reduce the total size of the enum
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -44,6 +44,9 @@ pub(crate) struct RunArgs {
     /// Force streaming while node is syncing
     #[clap(long)]
     pub stream_while_syncing: bool,
+    /// Tells whether to validate the genesis file before starting
+    #[clap(long)]
+    pub validate_genesis: bool,
     /// Sets the concurrency for indexing. Note: concurrency (set to 2+) may lead to warnings due to tight constraints between transactions and receipts (those will get resolved eventually, but unless it is the second pass of indexing, concurrency won't help at the moment).
     #[clap(long, default_value = "1")]
     pub concurrency: std::num::NonZeroU16,
@@ -65,6 +68,7 @@ impl RunArgs {
             } else {
                 near_indexer::AwaitForNodeSyncedEnum::WaitForFullSync
             },
+            validate_genesis: self.validate_genesis,
         }
     }
 }
@@ -129,6 +133,8 @@ pub(crate) struct InitConfigArgs {
     /// Specify a custom download URL for the genesis-file.
     #[clap(long)]
     pub download_genesis_url: Option<String>,
+    #[clap(long)]
+    pub donwload_genesis_records_url: Option<String>,
     /// Customize max_gas_burnt_view runtime limit.  If not specified, value
     /// from genesis configuration will be taken.
     #[clap(long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,10 @@ fn main() {
             config.genesis.as_ref().map(AsRef::as_ref),
             config.download_genesis,
             config.download_genesis_url.as_ref().map(AsRef::as_ref),
+            config
+                .donwload_genesis_records_url
+                .as_ref()
+                .map(AsRef::as_ref),
             config.download_config,
             config.download_config_url.as_ref().map(AsRef::as_ref),
             config.boot_nodes.as_ref().map(AsRef::as_ref),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,5 @@
 use near_indexer_primitives::types;
+use near_o11y::WithSpanContextExt;
 
 /// Fetches the status to retrieve `latest_block_height` to determine if we need to fetch
 /// entire block or we already fetched this block.
@@ -6,9 +7,10 @@ pub(crate) async fn fetch_latest_block(
     client: &actix::Addr<near_client::ViewClientActor>,
 ) -> anyhow::Result<u64> {
     let block = client
-        .send(near_client::GetBlock(types::BlockReference::Finality(
-            types::Finality::Final,
-        )))
+        .send(
+            near_client::GetBlock(types::BlockReference::Finality(types::Finality::Final))
+                .with_span_context(),
+        )
         .await??;
     Ok(block.header.height)
 }


### PR DESCRIPTION
* Upgrade Indexer Framework to be based on [nearcore 1.31.0-rc.4](https://github.com/near/nearcore/commit/f709cdc89adfa0594df5ac20212e75402a1b862e)

### Heads-up

Some updates on the `nearcore` side affected the Indexer Framework:
- `near_client` calls require the usage of `near_o11y::WithSpanContextExt`. Thus we depend on `near-o11y` explicitly since this version
- `init_configs` function has been extended with a parameter `download_records_url: Option<&str>`. Thus `init` command of the Lake Indexer has been extended with the parameter `donwload_genesis_records_url`
- `IndexerConfig` requires a new parameter `validate_genesis: bool` so the `run` command has been extended with the key `--validate-genesis`