### PR TITLE
chore: Upgrade `nearcore` to `1.31.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.20
+
+* Upgrade Indexer Framework to be based on [nearcore 1.31.1](https://github.com/near/nearcore/commit/825bc1b44b6d5080cc610d542e2b57f329d7aed9)
+
 ## 0.1.19
 
 * Upgrade Indexer Framework to be based on [nearcore 1.31.0-rc.4](https://github.com/near/nearcore/commit/f709cdc89adfa0594df5ac20212e75402a1b862e)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1454,7 +1454,7 @@ dependencies = [
 [[package]]
 name = "delay-detector"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "cpu-time",
  "tracing",
@@ -2532,7 +2532,7 @@ dependencies = [
 [[package]]
 name = "near-account-id"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -2542,7 +2542,7 @@ dependencies = [
 [[package]]
 name = "near-cache"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "lru",
 ]
@@ -2550,7 +2550,7 @@ dependencies = [
 [[package]]
 name = "near-chain"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "actix",
  "ansi_term",
@@ -2585,7 +2585,7 @@ dependencies = [
 [[package]]
 name = "near-chain-configs"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2603,7 +2603,7 @@ dependencies = [
 [[package]]
 name = "near-chain-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "chrono",
  "near-crypto",
@@ -2615,7 +2615,7 @@ dependencies = [
 [[package]]
 name = "near-chunks"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "actix",
  "borsh",
@@ -2639,7 +2639,7 @@ dependencies = [
 [[package]]
 name = "near-chunks-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "near-chain-primitives",
  "near-primitives",
@@ -2648,7 +2648,7 @@ dependencies = [
 [[package]]
 name = "near-client"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "actix",
  "actix-rt",
@@ -2691,7 +2691,7 @@ dependencies = [
 [[package]]
 name = "near-client-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "actix",
  "chrono",
@@ -2710,7 +2710,7 @@ dependencies = [
 [[package]]
 name = "near-crypto"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "blake2",
  "borsh",
@@ -2734,7 +2734,7 @@ dependencies = [
 [[package]]
 name = "near-dyn-configs"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "near-o11y",
  "once_cell",
@@ -2744,7 +2744,7 @@ dependencies = [
 [[package]]
 name = "near-epoch-manager"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "borsh",
  "near-cache",
@@ -2765,7 +2765,7 @@ dependencies = [
 [[package]]
 name = "near-indexer"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "actix",
  "anyhow",
@@ -2792,7 +2792,7 @@ dependencies = [
 [[package]]
 name = "near-indexer-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "near-primitives",
  "serde",
@@ -2802,7 +2802,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "actix",
  "actix-cors",
@@ -2830,7 +2830,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "actix-http",
  "awc",
@@ -2844,7 +2844,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -2888,7 +2888,7 @@ dependencies = [
 [[package]]
 name = "near-mainnet-res"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
@@ -2899,7 +2899,7 @@ dependencies = [
 [[package]]
 name = "near-network"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "actix",
  "anyhow",
@@ -2946,7 +2946,7 @@ dependencies = [
 [[package]]
 name = "near-o11y"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "actix",
  "atty",
@@ -2971,7 +2971,7 @@ dependencies = [
 [[package]]
 name = "near-performance-metrics"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "actix",
  "bitflags",
@@ -2988,7 +2988,7 @@ dependencies = [
 [[package]]
 name = "near-performance-metrics-macros"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "quote",
  "syn",
@@ -2997,7 +2997,7 @@ dependencies = [
 [[package]]
 name = "near-pool"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "borsh",
  "near-crypto",
@@ -3010,7 +3010,7 @@ dependencies = [
 [[package]]
 name = "near-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "arbitrary",
  "borsh",
@@ -3043,7 +3043,7 @@ dependencies = [
 [[package]]
 name = "near-primitives-core"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "arbitrary",
  "base64",
@@ -3062,7 +3062,7 @@ dependencies = [
 [[package]]
 name = "near-rosetta-rpc"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "actix",
  "actix-cors",
@@ -3091,7 +3091,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-core"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "quote",
  "serde",
@@ -3101,7 +3101,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-macro"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "fs2",
  "near-rpc-error-core",
@@ -3112,17 +3112,17 @@ dependencies = [
 [[package]]
 name = "near-stable-hasher"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 
 [[package]]
 name = "near-stdx"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 
 [[package]]
 name = "near-store"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3155,7 +3155,7 @@ dependencies = [
 [[package]]
 name = "near-telemetry"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "actix",
  "awc",
@@ -3174,7 +3174,7 @@ dependencies = [
 [[package]]
 name = "near-vm-errors"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "borsh",
  "near-account-id",
@@ -3187,7 +3187,7 @@ dependencies = [
 [[package]]
 name = "near-vm-logic"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "borsh",
  "byteorder",
@@ -3209,7 +3209,7 @@ dependencies = [
 [[package]]
 name = "near-vm-runner"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3241,7 +3241,7 @@ dependencies = [
 [[package]]
 name = "nearcore"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3311,7 +3311,7 @@ dependencies = [
 [[package]]
 name = "node-runtime"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=f709cdc89adfa0594df5ac20212e75402a1b862e#f709cdc89adfa0594df5ac20212e75402a1b862e"
+source = "git+https://github.com/near/nearcore?rev=825bc1b44b6d5080cc610d542e2b57f329d7aed9#825bc1b44b6d5080cc610d542e2b57f329d7aed9"
 dependencies = [
  "borsh",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-lake"
-version = "0.1.19"
+version = "0.1.20"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.65.0"
@@ -25,7 +25,7 @@ tokio-stream = { version = "0.1" }
 tracing = "0.1.34"
 tracing-subscriber = "0.2.4"
 
-near-indexer = { git = "https://github.com/near/nearcore", rev = "f709cdc89adfa0594df5ac20212e75402a1b862e" }
-near-indexer-primitives = { git = "https://github.com/near/nearcore", rev = "f709cdc89adfa0594df5ac20212e75402a1b862e" }
-near-client = { git = "https://github.com/near/nearcore", rev = "f709cdc89adfa0594df5ac20212e75402a1b862e" }
-near-o11y = { git = "https://github.com/near/nearcore", rev = "f709cdc89adfa0594df5ac20212e75402a1b862e" }
+near-indexer = { git = "https://github.com/near/nearcore", rev = "825bc1b44b6d5080cc610d542e2b57f329d7aed9" }
+near-indexer-primitives = { git = "https://github.com/near/nearcore", rev = "825bc1b44b6d5080cc610d542e2b57f329d7aed9" }
+near-client = { git = "https://github.com/near/nearcore", rev = "825bc1b44b6d5080cc610d542e2b57f329d7aed9" }
+near-o11y = { git = "https://github.com/near/nearcore", rev = "825bc1b44b6d5080cc610d542e2b57f329d7aed9" }


### PR DESCRIPTION
Points to https://github.com/near/near-lake-indexer/pull/63 as that PR fixes the issues with CI