### PR TITLE
chore: Upgrade nearcore dependency to the 1.32.0-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## 0.1.21-rc.1
+## 0.1.21
 
-* Upgrade Indexer Framework to be based on [nearcore 1.32.0-906e6f3](https://github.com/near/nearcore/commit/906e6f32b80e0976d783c822b7c95871d3cf728b)
+* Upgrade Indexer Framework to be based on [nearcore 1.32.0-rc.1](https://github.com/near/nearcore/releases/tag/1.32.0-rc.1)
+* Updated the minimal Rust version to `1.67.1`
 
 ## 0.1.21-rc.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.21-rc.1
+
+* Upgrade Indexer Framework to be based on [nearcore 1.32.0-906e6f3](https://github.com/near/nearcore/commit/906e6f32b80e0976d783c822b7c95871d3cf728b)
+
 ## 0.1.21-rc.0
 
 * Add support for meta transactions by upgrading near crates to [0.16](https://github.com/near/nearcore/commit/1a18003fe2f0873caac670bc0b86f8d59842b20a)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,7 +1542,7 @@ dependencies = [
 [[package]]
 name = "delay-detector"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "cpu-time",
  "tracing",
@@ -2677,7 +2677,7 @@ dependencies = [
 [[package]]
 name = "near-account-id"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "arbitrary",
  "borsh 0.10.2",
@@ -2687,7 +2687,7 @@ dependencies = [
 [[package]]
 name = "near-async"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "actix",
  "derive-enum-from-into",
@@ -2702,7 +2702,7 @@ dependencies = [
 [[package]]
 name = "near-cache"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "lru",
 ]
@@ -2710,7 +2710,7 @@ dependencies = [
 [[package]]
 name = "near-chain"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "actix",
  "ansi_term",
@@ -2746,7 +2746,7 @@ dependencies = [
 [[package]]
 name = "near-chain-configs"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2767,7 +2767,7 @@ dependencies = [
 [[package]]
 name = "near-chain-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "chrono",
  "near-crypto",
@@ -2779,7 +2779,7 @@ dependencies = [
 [[package]]
 name = "near-chunks"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "actix",
  "borsh 0.10.2",
@@ -2805,7 +2805,7 @@ dependencies = [
 [[package]]
 name = "near-chunks-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "near-chain-primitives",
  "near-primitives",
@@ -2814,7 +2814,7 @@ dependencies = [
 [[package]]
 name = "near-client"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "actix",
  "actix-rt",
@@ -2859,7 +2859,7 @@ dependencies = [
 [[package]]
 name = "near-client-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "actix",
  "chrono",
@@ -2878,7 +2878,7 @@ dependencies = [
 [[package]]
 name = "near-config-utils"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -2889,7 +2889,7 @@ dependencies = [
 [[package]]
 name = "near-crypto"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "blake2",
  "borsh 0.10.2",
@@ -2915,7 +2915,7 @@ dependencies = [
 [[package]]
 name = "near-dyn-configs"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -2933,7 +2933,7 @@ dependencies = [
 [[package]]
 name = "near-epoch-manager"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "borsh 0.10.2",
  "near-cache",
@@ -2954,7 +2954,7 @@ dependencies = [
 [[package]]
 name = "near-indexer"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "actix",
  "anyhow",
@@ -2981,7 +2981,7 @@ dependencies = [
 [[package]]
 name = "near-indexer-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "near-primitives",
  "serde",
@@ -2991,7 +2991,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "actix",
  "actix-cors",
@@ -3019,7 +3019,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "actix-http",
  "awc",
@@ -3033,7 +3033,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "near-lake"
-version = "0.1.21-rc.1"
+version = "0.1.21"
 dependencies = [
  "actix",
  "anyhow",
@@ -3077,7 +3077,7 @@ dependencies = [
 [[package]]
 name = "near-mainnet-res"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
@@ -3088,7 +3088,7 @@ dependencies = [
 [[package]]
 name = "near-network"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "actix",
  "anyhow",
@@ -3138,7 +3138,7 @@ dependencies = [
 [[package]]
 name = "near-o11y"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "actix",
  "atty",
@@ -3163,7 +3163,7 @@ dependencies = [
 [[package]]
 name = "near-performance-metrics"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "actix",
  "bitflags",
@@ -3180,7 +3180,7 @@ dependencies = [
 [[package]]
 name = "near-performance-metrics-macros"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "quote",
  "syn",
@@ -3189,7 +3189,7 @@ dependencies = [
 [[package]]
 name = "near-pool"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "borsh 0.10.2",
  "near-crypto",
@@ -3202,7 +3202,7 @@ dependencies = [
 [[package]]
 name = "near-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "arbitrary",
  "borsh 0.10.2",
@@ -3236,7 +3236,7 @@ dependencies = [
 [[package]]
 name = "near-primitives-core"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "arbitrary",
  "base64",
@@ -3256,7 +3256,7 @@ dependencies = [
 [[package]]
 name = "near-rosetta-rpc"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "actix",
  "actix-cors",
@@ -3285,7 +3285,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-core"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "quote",
  "serde",
@@ -3295,7 +3295,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-macro"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "fs2",
  "near-rpc-error-core",
@@ -3306,7 +3306,7 @@ dependencies = [
 [[package]]
 name = "near-stable-hasher"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 
 [[package]]
 name = "near-stdx"
@@ -3317,7 +3317,7 @@ checksum = "6c05ded9a90c087aaebfafdf01f2801f5d31817f9a3514ce09aed270001d650e"
 [[package]]
 name = "near-store"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "anyhow",
  "borsh 0.10.2",
@@ -3350,7 +3350,7 @@ dependencies = [
 [[package]]
 name = "near-telemetry"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "actix",
  "awc",
@@ -3369,7 +3369,7 @@ dependencies = [
 [[package]]
 name = "near-vm-errors"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "borsh 0.10.2",
  "near-account-id",
@@ -3382,7 +3382,7 @@ dependencies = [
 [[package]]
 name = "near-vm-logic"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "borsh 0.10.2",
  "ed25519-dalek",
@@ -3403,7 +3403,7 @@ dependencies = [
 [[package]]
 name = "near-vm-runner"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "anyhow",
  "borsh 0.10.2",
@@ -3435,7 +3435,7 @@ dependencies = [
 [[package]]
 name = "nearcore"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3519,7 +3519,7 @@ dependencies = [
 [[package]]
 name = "node-runtime"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
+source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
 dependencies = [
  "borsh 0.10.2",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -860,7 +860,17 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15bf3650200d8bffa99015595e10f1fbd17de07abbc25bb067da79e769939bfa"
 dependencies = [
- "borsh-derive",
+ "borsh-derive 0.9.3",
+ "hashbrown 0.11.2",
+]
+
+[[package]]
+name = "borsh"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40f9ca3698b2e4cb7c15571db0abc5551dca417a21ae8140460b50309bb2cc62"
+dependencies = [
+ "borsh-derive 0.10.2",
  "hashbrown 0.11.2",
 ]
 
@@ -870,8 +880,21 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6441c552f230375d18e3cc377677914d2ca2b0d36e52129fe15450a2dce46775"
 dependencies = [
- "borsh-derive-internal",
- "borsh-schema-derive-internal",
+ "borsh-derive-internal 0.9.3",
+ "borsh-schema-derive-internal 0.9.3",
+ "proc-macro-crate",
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598b3eacc6db9c3ee57b22707ad8f6a8d2f6d442bfe24ffeb8cbb70ca59e6a35"
+dependencies = [
+ "borsh-derive-internal 0.10.2",
+ "borsh-schema-derive-internal 0.10.2",
  "proc-macro-crate",
  "proc-macro2",
  "syn",
@@ -889,10 +912,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh-derive-internal"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186b734fa1c9f6743e90c95d7233c9faab6360d1a96d4ffa19d9cfd1e9350f8a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "borsh-schema-derive-internal"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "borsh-schema-derive-internal"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b7ff1008316626f485991b960ade129253d4034014616b94f309a15366cc49"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1497,7 +1542,7 @@ dependencies = [
 [[package]]
 name = "delay-detector"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "cpu-time",
  "tracing",
@@ -2632,17 +2677,17 @@ dependencies = [
 [[package]]
 name = "near-account-id"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "arbitrary",
- "borsh",
+ "borsh 0.10.2",
  "serde",
 ]
 
 [[package]]
 name = "near-async"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "actix",
  "derive-enum-from-into",
@@ -2657,7 +2702,7 @@ dependencies = [
 [[package]]
 name = "near-cache"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "lru",
 ]
@@ -2665,12 +2710,12 @@ dependencies = [
 [[package]]
 name = "near-chain"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "actix",
  "ansi_term",
  "assert_matches",
- "borsh",
+ "borsh 0.10.2",
  "chrono",
  "crossbeam-channel",
  "delay-detector",
@@ -2701,7 +2746,7 @@ dependencies = [
 [[package]]
 name = "near-chain-configs"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2722,7 +2767,7 @@ dependencies = [
 [[package]]
 name = "near-chain-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "chrono",
  "near-crypto",
@@ -2734,10 +2779,10 @@ dependencies = [
 [[package]]
 name = "near-chunks"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "actix",
- "borsh",
+ "borsh 0.10.2",
  "chrono",
  "futures",
  "lru",
@@ -2760,7 +2805,7 @@ dependencies = [
 [[package]]
 name = "near-chunks-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "near-chain-primitives",
  "near-primitives",
@@ -2769,13 +2814,13 @@ dependencies = [
 [[package]]
 name = "near-client"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "actix",
  "actix-rt",
  "ansi_term",
  "async-trait",
- "borsh",
+ "borsh 0.10.2",
  "chrono",
  "delay-detector",
  "derive_more",
@@ -2814,7 +2859,7 @@ dependencies = [
 [[package]]
 name = "near-client-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "actix",
  "chrono",
@@ -2833,18 +2878,21 @@ dependencies = [
 [[package]]
 name = "near-config-utils"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
+ "anyhow",
  "json_comments",
+ "thiserror",
+ "tracing",
 ]
 
 [[package]]
 name = "near-crypto"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "blake2",
- "borsh",
+ "borsh 0.10.2",
  "bs58",
  "c2-chacha",
  "curve25519-dalek",
@@ -2867,7 +2915,7 @@ dependencies = [
 [[package]]
 name = "near-dyn-configs"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -2885,9 +2933,9 @@ dependencies = [
 [[package]]
 name = "near-epoch-manager"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
- "borsh",
+ "borsh 0.10.2",
  "near-cache",
  "near-chain-configs",
  "near-chain-primitives",
@@ -2906,7 +2954,7 @@ dependencies = [
 [[package]]
 name = "near-indexer"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "actix",
  "anyhow",
@@ -2933,7 +2981,7 @@ dependencies = [
 [[package]]
 name = "near-indexer-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "near-primitives",
  "serde",
@@ -2943,7 +2991,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "actix",
  "actix-cors",
@@ -2971,7 +3019,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "actix-http",
  "awc",
@@ -2985,7 +3033,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -3000,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "near-lake"
-version = "0.1.21-rc.0"
+version = "0.1.21-rc.1"
 dependencies = [
  "actix",
  "anyhow",
@@ -3029,7 +3077,7 @@ dependencies = [
 [[package]]
 name = "near-mainnet-res"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
@@ -3040,14 +3088,14 @@ dependencies = [
 [[package]]
 name = "near-network"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "actix",
  "anyhow",
  "arc-swap",
  "assert_matches",
  "async-trait",
- "borsh",
+ "borsh 0.10.2",
  "bytes",
  "bytesize",
  "chrono",
@@ -3090,7 +3138,7 @@ dependencies = [
 [[package]]
 name = "near-o11y"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "actix",
  "atty",
@@ -3115,7 +3163,7 @@ dependencies = [
 [[package]]
 name = "near-performance-metrics"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "actix",
  "bitflags",
@@ -3132,7 +3180,7 @@ dependencies = [
 [[package]]
 name = "near-performance-metrics-macros"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "quote",
  "syn",
@@ -3141,9 +3189,9 @@ dependencies = [
 [[package]]
 name = "near-pool"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
- "borsh",
+ "borsh 0.10.2",
  "near-crypto",
  "near-o11y",
  "near-primitives",
@@ -3154,10 +3202,10 @@ dependencies = [
 [[package]]
 name = "near-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "arbitrary",
- "borsh",
+ "borsh 0.10.2",
  "bytesize",
  "cfg-if 1.0.0",
  "chrono",
@@ -3188,11 +3236,11 @@ dependencies = [
 [[package]]
 name = "near-primitives-core"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "arbitrary",
  "base64",
- "borsh",
+ "borsh 0.10.2",
  "bs58",
  "derive_more",
  "enum-map",
@@ -3208,7 +3256,7 @@ dependencies = [
 [[package]]
 name = "near-rosetta-rpc"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "actix",
  "actix-cors",
@@ -3237,7 +3285,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-core"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "quote",
  "serde",
@@ -3247,7 +3295,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-macro"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "fs2",
  "near-rpc-error-core",
@@ -3258,7 +3306,7 @@ dependencies = [
 [[package]]
 name = "near-stable-hasher"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 
 [[package]]
 name = "near-stdx"
@@ -3269,10 +3317,10 @@ checksum = "6c05ded9a90c087aaebfafdf01f2801f5d31817f9a3514ce09aed270001d650e"
 [[package]]
 name = "near-store"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.2",
  "byteorder",
  "bytesize",
  "crossbeam",
@@ -3302,7 +3350,7 @@ dependencies = [
 [[package]]
 name = "near-telemetry"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "actix",
  "awc",
@@ -3321,9 +3369,9 @@ dependencies = [
 [[package]]
 name = "near-vm-errors"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
- "borsh",
+ "borsh 0.10.2",
  "near-account-id",
  "near-rpc-error-macro",
  "serde",
@@ -3334,9 +3382,9 @@ dependencies = [
 [[package]]
 name = "near-vm-logic"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
- "borsh",
+ "borsh 0.10.2",
  "ed25519-dalek",
  "near-account-id",
  "near-crypto",
@@ -3355,10 +3403,10 @@ dependencies = [
 [[package]]
 name = "near-vm-runner"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "anyhow",
- "borsh",
+ "borsh 0.10.2",
  "loupe",
  "memoffset",
  "near-cache",
@@ -3387,14 +3435,14 @@ dependencies = [
 [[package]]
 name = "nearcore"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
  "actix",
  "actix-rt",
  "actix-web",
  "anyhow",
  "awc",
- "borsh",
+ "borsh 0.10.2",
  "byteorder",
  "chrono",
  "delay-detector",
@@ -3471,9 +3519,9 @@ dependencies = [
 [[package]]
 name = "node-runtime"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=1a18003fe2f0873caac670bc0b86f8d59842b20a#1a18003fe2f0873caac670bc0b86f8d59842b20a"
+source = "git+https://github.com/near/nearcore?rev=906e6f32b80e0976d783c822b7c95871d3cf728b#906e6f32b80e0976d783c822b7c95871d3cf728b"
 dependencies = [
- "borsh",
+ "borsh 0.10.2",
  "hex",
  "near-chain-configs",
  "near-crypto",
@@ -5721,7 +5769,7 @@ checksum = "5a3fac37da3c625e98708c5dd92d3f642aaf700fd077168d3d0fff277ec6a165"
 dependencies = [
  "bincode",
  "blake3",
- "borsh",
+ "borsh 0.9.3",
  "cc",
  "digest 0.8.1",
  "errno",
@@ -5764,7 +5812,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f6edd0ba6c0bcf9b279186d4dbe81649dda3e5ef38f586865943de4dcd653f8"
 dependencies = [
  "bincode",
- "borsh",
+ "borsh 0.9.3",
  "byteorder",
  "dynasm",
  "dynasmrt",
@@ -6209,7 +6257,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e61de68ede9ffdd69c01664f65a178c5188b73f78faa21f0936016a888ff7c"
 dependencies = [
- "borsh",
+ "borsh 0.9.3",
  "byteorder",
  "crunchy",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "near-lake"
-version = "0.1.21-rc.0"
+version = "0.1.21-rc.1"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
-rust-version = "1.65.0"
+rust-version = "1.67.1"
 
 [dependencies]
 actix = "0.13.0"
@@ -25,7 +25,7 @@ tokio-stream = { version = "0.1" }
 tracing = "0.1.34"
 tracing-subscriber = "0.2.4"
 
-near-indexer = { git = "https://github.com/near/nearcore", rev = "1a18003fe2f0873caac670bc0b86f8d59842b20a" }
-near-indexer-primitives = { git = "https://github.com/near/nearcore", rev = "1a18003fe2f0873caac670bc0b86f8d59842b20a" }
-near-client = { git = "https://github.com/near/nearcore", rev = "1a18003fe2f0873caac670bc0b86f8d59842b20a" }
-near-o11y = { git = "https://github.com/near/nearcore", rev = "1a18003fe2f0873caac670bc0b86f8d59842b20a" }
+near-indexer = { git = "https://github.com/near/nearcore", rev = "906e6f32b80e0976d783c822b7c95871d3cf728b" }
+near-indexer-primitives = { git = "https://github.com/near/nearcore", rev = "906e6f32b80e0976d783c822b7c95871d3cf728b" }
+near-client = { git = "https://github.com/near/nearcore", rev = "906e6f32b80e0976d783c822b7c95871d3cf728b" }
+near-o11y = { git = "https://github.com/near/nearcore", rev = "906e6f32b80e0976d783c822b7c95871d3cf728b" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-lake"
-version = "0.1.21-rc.1"
+version = "0.1.21"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.67.1"
@@ -25,7 +25,7 @@ tokio-stream = { version = "0.1" }
 tracing = "0.1.34"
 tracing-subscriber = "0.2.4"
 
-near-indexer = { git = "https://github.com/near/nearcore", rev = "906e6f32b80e0976d783c822b7c95871d3cf728b" }
-near-indexer-primitives = { git = "https://github.com/near/nearcore", rev = "906e6f32b80e0976d783c822b7c95871d3cf728b" }
-near-client = { git = "https://github.com/near/nearcore", rev = "906e6f32b80e0976d783c822b7c95871d3cf728b" }
-near-o11y = { git = "https://github.com/near/nearcore", rev = "906e6f32b80e0976d783c822b7c95871d3cf728b" }
+near-indexer = { git = "https://github.com/near/nearcore", rev = "a6d14feb03af14912f9c6d41857fd4013c8654b8" }
+near-indexer-primitives = { git = "https://github.com/near/nearcore", rev = "a6d14feb03af14912f9c6d41857fd4013c8654b8" }
+near-client = { git = "https://github.com/near/nearcore", rev = "a6d14feb03af14912f9c6d41857fd4013c8654b8" }
+near-o11y = { git = "https://github.com/near/nearcore", rev = "a6d14feb03af14912f9c6d41857fd4013c8654b8" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,7 @@ fn main() {
         }
         SubCommand::Init(config) => near_indexer::init_configs(
             &home_dir,
-            config.chain_id.as_ref().map(AsRef::as_ref),
+            config.chain_id,
             config.account_id.map(|account_id_string| {
                 near_indexer::near_primitives::types::AccountId::try_from(account_id_string)
                     .expect("Received accound_id is not valid")


### PR DESCRIPTION
We continue working on supporting Meta Transactions landing with `nearcore` 1.32.0 release.

UPD:
I've updated the commit hash in this PR since the pre-release was created almost immediately after I submitted a PR.