### PR TITLE
chore: Upgrade `nearcore` dependencies to `1.33.0-rc.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.22
+
+* Upgrade Indexer Framework to be based on [nearcore 1.33.0-rc.1](https://github.com/near/nearcore/releases/tag/1.33.0-rc.1)
+* Updated the minimal Rust version to `1.68.0`
+
 ## 0.1.21
 
 * Upgrade Indexer Framework to be based on [nearcore 1.32.0-rc.1](https://github.com/near/nearcore/releases/tag/1.32.0-rc.1)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ dependencies = [
  "actix-service",
  "actix-utils",
  "ahash",
- "base64",
+ "base64 0.13.0",
  "bitflags",
  "brotli",
  "bytes",
@@ -399,6 +399,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "attohttpc"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "262c3f7f5d61249d8c00e5546e2685cd15ebeeb1bc0f3cc5449350a1cb07319e"
+dependencies = [
+ "http",
+ "log",
+ "native-tls",
+ "openssl",
+ "serde",
+ "serde_json",
+ "url",
+ "wildmatch",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,7 +444,7 @@ dependencies = [
  "actix-tls",
  "actix-utils",
  "ahash",
- "base64",
+ "base64 0.13.0",
  "bytes",
  "cfg-if 1.0.0",
  "cookie",
@@ -478,6 +494,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-creds"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeeee1a5defa63cba39097a510dfe63ef53658fc8995202a610f6a8a4d03639"
+dependencies = [
+ "attohttpc",
+ "dirs",
+ "rust-ini",
+ "serde",
+ "serde-xml-rs",
+ "thiserror",
+ "time 0.3.9",
+ "url",
+]
+
+[[package]]
 name = "aws-endpoint"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,6 +535,15 @@ dependencies = [
  "lazy_static",
  "percent-encoding",
  "tracing",
+]
+
+[[package]]
+name = "aws-region"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f92a8af5850d0ea0916ca3e015ab86951ded0bf4b70fd27896e81ae1dfb0af37"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]
@@ -768,6 +809,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,6 +899,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
  "generic-array 0.14.5",
+]
+
+[[package]]
+name = "block_on_proc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b872f3528eeeb4370ee73b51194dc1cd93680c2d0eb6c7a223889038d2c1a167"
+dependencies = [
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1542,7 +1599,7 @@ dependencies = [
 [[package]]
 name = "delay-detector"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "cpu-time",
  "tracing",
@@ -1609,6 +1666,7 @@ checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
 dependencies = [
  "block-buffer 0.10.2",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1630,6 +1688,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "dlv-list"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
 name = "dynasm"
@@ -2108,6 +2172,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "http"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2544,6 +2617,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
+name = "maybe-async"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f1b8c13cb1f814b634a96b2c725449fe7ed464a7b8781de8688be5ffbd3f305"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2618,6 +2702,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "minidom"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e9ce45d459e358790a285e7609ff5ae4cfab88b75f237e8838e62029dda397b"
+dependencies = [
+ "rxml",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2677,7 +2770,7 @@ dependencies = [
 [[package]]
 name = "near-account-id"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "arbitrary",
  "borsh 0.10.2",
@@ -2687,22 +2780,25 @@ dependencies = [
 [[package]]
 name = "near-async"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "actix",
  "derive-enum-from-into",
  "derive_more",
  "futures",
  "near-o11y",
+ "near-performance-metrics",
+ "near-primitives",
  "once_cell",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]
 name = "near-cache"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "lru",
 ]
@@ -2710,7 +2806,7 @@ dependencies = [
 [[package]]
 name = "near-chain"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "actix",
  "ansi_term",
@@ -2746,7 +2842,7 @@ dependencies = [
 [[package]]
 name = "near-chain-configs"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2767,7 +2863,7 @@ dependencies = [
 [[package]]
 name = "near-chain-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "chrono",
  "near-crypto",
@@ -2779,11 +2875,13 @@ dependencies = [
 [[package]]
 name = "near-chunks"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "actix",
  "borsh 0.10.2",
  "chrono",
+ "derive-enum-from-into",
+ "derive_more",
  "futures",
  "lru",
  "near-async",
@@ -2799,13 +2897,14 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
  "reed-solomon-erasure",
+ "time 0.3.9",
  "tracing",
 ]
 
 [[package]]
 name = "near-chunks-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "near-chain-primitives",
  "near-primitives",
@@ -2814,7 +2913,7 @@ dependencies = [
 [[package]]
 name = "near-client"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "actix",
  "actix-rt",
@@ -2859,7 +2958,7 @@ dependencies = [
 [[package]]
 name = "near-client-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "actix",
  "chrono",
@@ -2878,7 +2977,7 @@ dependencies = [
 [[package]]
 name = "near-config-utils"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -2889,7 +2988,7 @@ dependencies = [
 [[package]]
 name = "near-crypto"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "blake2",
  "borsh 0.10.2",
@@ -2915,7 +3014,7 @@ dependencies = [
 [[package]]
 name = "near-dyn-configs"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -2933,7 +3032,7 @@ dependencies = [
 [[package]]
 name = "near-epoch-manager"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "borsh 0.10.2",
  "near-cache",
@@ -2954,7 +3053,7 @@ dependencies = [
 [[package]]
 name = "near-indexer"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "actix",
  "anyhow",
@@ -2981,7 +3080,7 @@ dependencies = [
 [[package]]
 name = "near-indexer-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "near-primitives",
  "serde",
@@ -2991,7 +3090,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "actix",
  "actix-cors",
@@ -3019,7 +3118,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "actix-http",
  "awc",
@@ -3033,7 +3132,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -3048,7 +3147,7 @@ dependencies = [
 
 [[package]]
 name = "near-lake"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "actix",
  "anyhow",
@@ -3077,7 +3176,7 @@ dependencies = [
 [[package]]
 name = "near-mainnet-res"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
@@ -3088,7 +3187,7 @@ dependencies = [
 [[package]]
 name = "near-network"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "actix",
  "anyhow",
@@ -3118,6 +3217,7 @@ dependencies = [
  "once_cell",
  "opentelemetry",
  "parking_lot 0.12.1",
+ "pin-project",
  "protobuf 3.0.2",
  "protobuf-codegen",
  "rand 0.8.5",
@@ -3138,7 +3238,7 @@ dependencies = [
 [[package]]
 name = "near-o11y"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "actix",
  "atty",
@@ -3163,7 +3263,7 @@ dependencies = [
 [[package]]
 name = "near-performance-metrics"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "actix",
  "bitflags",
@@ -3180,7 +3280,7 @@ dependencies = [
 [[package]]
 name = "near-performance-metrics-macros"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "quote",
  "syn",
@@ -3189,7 +3289,7 @@ dependencies = [
 [[package]]
 name = "near-pool"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "borsh 0.10.2",
  "near-crypto",
@@ -3202,7 +3302,7 @@ dependencies = [
 [[package]]
 name = "near-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "arbitrary",
  "borsh 0.10.2",
@@ -3230,16 +3330,18 @@ dependencies = [
  "smart-default",
  "strum",
  "thiserror",
+ "time 0.3.9",
+ "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "near-primitives-core"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "arbitrary",
- "base64",
+ "base64 0.13.0",
  "borsh 0.10.2",
  "bs58",
  "derive_more",
@@ -3256,7 +3358,7 @@ dependencies = [
 [[package]]
 name = "near-rosetta-rpc"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "actix",
  "actix-cors",
@@ -3285,7 +3387,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-core"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "quote",
  "serde",
@@ -3295,7 +3397,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-macro"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "fs2",
  "near-rpc-error-core",
@@ -3306,7 +3408,7 @@ dependencies = [
 [[package]]
 name = "near-stable-hasher"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 
 [[package]]
 name = "near-stdx"
@@ -3317,7 +3419,7 @@ checksum = "6c05ded9a90c087aaebfafdf01f2801f5d31817f9a3514ce09aed270001d650e"
 [[package]]
 name = "near-store"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "anyhow",
  "borsh 0.10.2",
@@ -3350,7 +3452,7 @@ dependencies = [
 [[package]]
 name = "near-telemetry"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "actix",
  "awc",
@@ -3369,7 +3471,7 @@ dependencies = [
 [[package]]
 name = "near-vm-errors"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "borsh 0.10.2",
  "near-account-id",
@@ -3382,7 +3484,7 @@ dependencies = [
 [[package]]
 name = "near-vm-logic"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "borsh 0.10.2",
  "ed25519-dalek",
@@ -3403,7 +3505,7 @@ dependencies = [
 [[package]]
 name = "near-vm-runner"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "anyhow",
  "borsh 0.10.2",
@@ -3435,7 +3537,7 @@ dependencies = [
 [[package]]
 name = "nearcore"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3479,6 +3581,7 @@ dependencies = [
  "rand 0.8.5",
  "rayon",
  "rlimit",
+ "rust-s3",
  "serde",
  "serde_ignored",
  "serde_json",
@@ -3519,7 +3622,7 @@ dependencies = [
 [[package]]
 name = "node-runtime"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=a6d14feb03af14912f9c6d41857fd4013c8654b8#a6d14feb03af14912f9c6d41857fd4013c8654b8"
+source = "git+https://github.com/near/nearcore?rev=d04637da50e157e7fd583df2b13201a01972b6eb#d04637da50e157e7fd583df2b13201a01972b6eb"
 dependencies = [
  "borsh 0.10.2",
  "hex",
@@ -3756,6 +3859,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985cc35d832d412224b2cffe2f9194b1b89b6aa5d0bef76d080dce09d90e62bd"
 dependencies = [
  "opentelemetry",
+]
+
+[[package]]
+name = "ordered-multimap"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -4430,6 +4543,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.11.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
+dependencies = [
+ "base64 0.21.0",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util 0.7.2",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4498,6 +4650,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-ini"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
+dependencies = [
+ "cfg-if 1.0.0",
+ "ordered-multimap",
+]
+
+[[package]]
+name = "rust-s3"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6009d9d4cf910505534d62d380a0aa305805a2af0b5c3ad59a3024a0715b847"
+dependencies = [
+ "async-trait",
+ "aws-creds",
+ "aws-region",
+ "base64 0.13.0",
+ "block_on_proc",
+ "cfg-if 1.0.0",
+ "hex",
+ "hmac",
+ "http",
+ "log",
+ "maybe-async",
+ "md5",
+ "minidom",
+ "percent-encoding",
+ "reqwest",
+ "serde",
+ "serde-xml-rs",
+ "serde_derive",
+ "sha2 0.10.2",
+ "thiserror",
+ "time 0.3.9",
+ "tokio",
+ "tokio-stream",
+ "url",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4553,7 +4747,7 @@ version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "log",
  "ring",
  "sct",
@@ -4577,6 +4771,25 @@ name = "rustversion"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
+
+[[package]]
+name = "rxml"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a071866b8c681dc2cfffa77184adc32b57b0caad4e620b6292609703bceb804"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "rxml_validation",
+ "smartstring",
+ "tokio",
+]
+
+[[package]]
+name = "rxml_validation"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53bc79743f9a66c2fb1f951cd83735f275d46bfe466259fbc5897bb60a0d00ee"
 
 [[package]]
 name = "ryu"
@@ -4696,6 +4909,18 @@ checksum = "d733da87e79faaac25616e33d26299a41143fd4cd42746cbb0e91d8feea243fd"
 dependencies = [
  "byteorder",
  "serde",
+]
+
+[[package]]
+name = "serde-xml-rs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65162e9059be2f6a3421ebbb4fef3e74b7d9e7c60c50a0e292c6239f19f1edfa"
+dependencies = [
+ "log",
+ "serde",
+ "thiserror",
+ "xml-rs",
 ]
 
 [[package]]
@@ -4889,6 +5114,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "smartstring"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e714dff2b33f2321fdcd475b71cec79781a692d846f37f415fb395a1d2bcd48e"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "socket2"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4950,7 +5184,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7e94b1ec00bad60e6410e058b52f1c66de3dc5fe4d62d09b3e52bb7d3b73e25"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "crc",
  "lazy_static",
  "md-5",
@@ -5108,6 +5342,7 @@ dependencies = [
  "itoa",
  "libc",
  "num_threads",
+ "serde",
  "time-macros",
 ]
 
@@ -5262,7 +5497,7 @@ checksum = "ff08f4649d10a70ffa3522ca559031285d8e421d727ac85c60825761818f5d0a"
 dependencies = [
  "async-stream",
  "async-trait",
- "base64",
+ "base64 0.13.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -5660,6 +5895,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f741de44b75e14c35df886aff5f1eb73aa114fa5d4d00dcd37b5e01259bf3b2"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5687,6 +5934,19 @@ name = "wasm-bindgen-shared"
 version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+
+[[package]]
+name = "wasm-streams"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bbae3363c08332cadccd13b67db371814cd214c2524020932f0804b8cf7c078"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "wasmer-compiler-near"
@@ -6085,6 +6345,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wildmatch"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee583bdc5ff1cf9db20e9db5bb3ff4c3089a8f6b8b31aff265c9aba85812db86"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6214,6 +6480,21 @@ name = "windows_x86_64_msvc"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
 
 [[package]]
 name = "xmlparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-lake"
-version = "0.1.21"
+version = "0.1.22"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.67.1"
@@ -25,7 +25,7 @@ tokio-stream = { version = "0.1" }
 tracing = "0.1.34"
 tracing-subscriber = "0.2.4"
 
-near-indexer = { git = "https://github.com/near/nearcore", rev = "a6d14feb03af14912f9c6d41857fd4013c8654b8" }
-near-indexer-primitives = { git = "https://github.com/near/nearcore", rev = "a6d14feb03af14912f9c6d41857fd4013c8654b8" }
-near-client = { git = "https://github.com/near/nearcore", rev = "a6d14feb03af14912f9c6d41857fd4013c8654b8" }
-near-o11y = { git = "https://github.com/near/nearcore", rev = "a6d14feb03af14912f9c6d41857fd4013c8654b8" }
+near-indexer = { git = "https://github.com/near/nearcore", rev = "d04637da50e157e7fd583df2b13201a01972b6eb" }
+near-indexer-primitives = { git = "https://github.com/near/nearcore", rev = "d04637da50e157e7fd583df2b13201a01972b6eb" }
+near-client = { git = "https://github.com/near/nearcore", rev = "d04637da50e157e7fd583df2b13201a01972b6eb" }
+near-o11y = { git = "https://github.com/near/nearcore", rev = "d04637da50e157e7fd583df2b13201a01972b6eb" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "near-lake"
 version = "0.1.22"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
-rust-version = "1.67.1"
+rust-version = "1.68.0"
 
 [dependencies]
 actix = "0.13.0"


### PR DESCRIPTION
- chore: Upgrade `nearcore` to `1.33.0-rc.1`
- build: Bump minimal rust version to `1.68.0`
