### PR TITLE
feat: add localnet Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.github
+scripts
+target
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM rust:1.71 AS builder
+WORKDIR /tmp/
+
+# Copy from nearcore:
+# https://github.com/near/nearcore/blob/master/Dockerfile
+RUN apt-get update -qq && \
+    apt-get install -y \
+        git \
+        cmake \
+        g++ \
+        pkg-config \
+        libssl-dev \
+        curl \
+        llvm \
+        clang
+
+COPY . .
+
+# build for release
+RUN cargo build --release
+
+FROM debian:bookworm-slim as runtime
+WORKDIR /near-lake-app
+
+RUN apt update && apt install -yy openssl ca-certificates jq
+
+COPY --from=builder /tmp/target/release/near-lake .
+COPY ./entrypoint.sh entrypoint.sh
+ENTRYPOINT [ "./entrypoint.sh" ]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Initialize NEAR Lake to generate config and genesis
+/near-lake-app/near-lake init --chain-id localnet
+
+# Tweak nearcore config to track all shards
+tmp=$(mktemp)
+jq '.tracked_shards = [0]' /root/.near/config.json >"$tmp" && mv "$tmp" /root/.near/config.json
+
+/near-lake-app/near-lake run "$@"


### PR DESCRIPTION
Not sure if this is going to be useful for the general audience, but we are using Lake Indexer in our integration tests and this is the Docker image we are planning to use. I have also published it on [ghcr](https://github.com/orgs/near/packages/container/package/near-lake-indexer). Happy to transfer ownership if someone else wants to manage it.