### PR TITLE
chore: 0.1.28 - Upgrade to nearcore 1.36.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.28
+
+* Upgrade Indexer Framework to be based on [nearcore 1.36.5](https://github.com/near/nearcore/releases/tag/1.36.5)
+
 ## 0.1.27
 
 * Upgrade Indexer Framework to be based on [nearcore 1.36.0-rc.1](https://github.com/near/nearcore/releases/tag/1.36.0-rc.1)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1782,8 +1782,8 @@ dependencies = [
 
 [[package]]
 name = "delay-detector"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "cpu-time",
  "tracing",
@@ -3182,8 +3182,8 @@ dependencies = [
 
 [[package]]
 name = "near-account-id"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "borsh 0.10.3",
  "serde",
@@ -3191,8 +3191,8 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "actix",
  "derive-enum-from-into",
@@ -3210,16 +3210,16 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "lru",
 ]
 
 [[package]]
 name = "near-chain"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "actix",
  "ansi_term",
@@ -3254,8 +3254,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3275,8 +3275,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "chrono",
  "near-crypto",
@@ -3287,8 +3287,8 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "actix",
  "borsh 0.10.3",
@@ -3318,8 +3318,8 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "near-chain-primitives",
  "near-primitives",
@@ -3327,8 +3327,8 @@ dependencies = [
 
 [[package]]
 name = "near-client"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3379,8 +3379,8 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "actix",
  "ansi_term",
@@ -3398,8 +3398,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -3409,8 +3409,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "blake2",
  "borsh 0.10.3",
@@ -3435,8 +3435,8 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -3453,8 +3453,8 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "borsh 0.10.3",
  "near-cache",
@@ -3474,16 +3474,16 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "near-primitives-core",
 ]
 
 [[package]]
 name = "near-indexer"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "actix",
  "anyhow",
@@ -3509,8 +3509,8 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "near-primitives",
  "serde",
@@ -3519,8 +3519,8 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "actix",
  "actix-cors",
@@ -3549,8 +3549,8 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "actix-http",
  "awc",
@@ -3563,8 +3563,8 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -3579,7 +3579,7 @@ dependencies = [
 
 [[package]]
 name = "near-lake"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "actix",
  "anyhow",
@@ -3608,8 +3608,8 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
@@ -3619,8 +3619,8 @@ dependencies = [
 
 [[package]]
 name = "near-network"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "actix",
  "anyhow",
@@ -3671,8 +3671,8 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "actix",
  "atty",
@@ -3699,8 +3699,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -3716,8 +3716,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "quote",
  "syn 2.0.39",
@@ -3725,8 +3725,8 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "borsh 0.10.3",
  "near-crypto",
@@ -3738,8 +3738,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "arbitrary",
  "borsh 0.10.3",
@@ -3774,8 +3774,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "arbitrary",
  "base64 0.21.5",
@@ -3795,8 +3795,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "actix",
  "actix-cors",
@@ -3826,8 +3826,8 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-core"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "quote",
  "serde",
@@ -3836,8 +3836,8 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-macro"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "fs2",
  "near-rpc-error-core",
@@ -3847,18 +3847,18 @@ dependencies = [
 
 [[package]]
 name = "near-stable-hasher"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 
 [[package]]
 name = "near-stdx"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 
 [[package]]
 name = "near-store"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3897,8 +3897,8 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "actix",
  "awc",
@@ -3916,8 +3916,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -3933,8 +3933,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -3954,8 +3954,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -3977,8 +3977,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "anyhow",
  "base64 0.21.5",
@@ -4025,8 +4025,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "indexmap 1.9.3",
  "num-traits",
@@ -4036,8 +4036,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "backtrace",
  "cc",
@@ -4058,8 +4058,8 @@ dependencies = [
 
 [[package]]
 name = "nearcore"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4147,8 +4147,8 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "1.36.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=f97e1ab46de694504ce3baeea7e0f724f1658b5f#f97e1ab46de694504ce3baeea7e0f724f1658b5f"
+version = "1.36.5"
+source = "git+https://github.com/near/nearcore?rev=d229b06d4826fe4d63b933dc437c1c7a8215af22#d229b06d4826fe4d63b933dc437c1c7a8215af22"
 dependencies = [
  "borsh 0.10.3",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-lake"
-version = "0.1.27"
+version = "0.1.28"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 
@@ -25,7 +25,7 @@ tokio-stream = { version = "0.1" }
 tracing = "0.1.34"
 tracing-subscriber = "0.2.4"
 
-near-indexer = { git = "https://github.com/near/nearcore", rev = "f97e1ab46de694504ce3baeea7e0f724f1658b5f" }
-near-indexer-primitives = { git = "https://github.com/near/nearcore", rev = "f97e1ab46de694504ce3baeea7e0f724f1658b5f" }
-near-client = { git = "https://github.com/near/nearcore", rev = "f97e1ab46de694504ce3baeea7e0f724f1658b5f" }
-near-o11y = { git = "https://github.com/near/nearcore", rev = "f97e1ab46de694504ce3baeea7e0f724f1658b5f" }
+near-indexer = { git = "https://github.com/near/nearcore", rev = "d229b06d4826fe4d63b933dc437c1c7a8215af22" }
+near-indexer-primitives = { git = "https://github.com/near/nearcore", rev = "d229b06d4826fe4d63b933dc437c1c7a8215af22" }
+near-client = { git = "https://github.com/near/nearcore", rev = "d229b06d4826fe4d63b933dc437c1c7a8215af22" }
+near-o11y = { git = "https://github.com/near/nearcore", rev = "d229b06d4826fe4d63b933dc437c1c7a8215af22" }

--- a/cross/x86_64-unknown-linux-gnu/Dockerfile
+++ b/cross/x86_64-unknown-linux-gnu/Dockerfile
@@ -1,14 +1,14 @@
-FROM ubuntu:18.04
+# syntax=docker/dockerfile-upstream:experimental
 
-# Copy from nearcore:
-# https://github.com/near/nearcore/blob/master/Dockerfile
-RUN apt-get update -qq && \
-    apt-get install -y \
-        git \
-        cmake \
-        g++ \
-        pkg-config \
-        libssl-dev \
-        curl \
-        llvm \
-        clang
+FROM ubuntu:22.04 as build
+
+RUN apt-get update -qq && apt-get install -y \
+    git \
+    cmake \
+    g++ \
+    pkg-config \
+    libssl-dev \
+    curl \
+    llvm \
+    clang \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
* Bump version to 0.1.28
* Upgrade `nearcore` dependency to 1.36.5
* [side] Update the Dockerfile for `cross` in an attempt to revive the CI build of the binary