### PR TITLE
fix: Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,117 +1,61 @@
-name: release
+name: Release Workflow
+
 on:
+  release:
+    types: [created, published]
   push:
-    # Enable when testing release infrastructure on a branch.
-    # branches:
-    # - ci/release-check
     tags:
-    - "[0-9]+.[0-9]+.[0-9]+"
-    - "[0-9]+.[0-9]+.[0-9]+-*"
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-*'
+
 jobs:
-  create-release:
-    name: create-release
-    runs-on: ubuntu-22.04
-    # env:
-      # Set to force version number, e.g., when no tag exists.
-      # NEAR_LAKE_VERSION: TEST-0.0.0
-    outputs:
-      upload_url: ${{ steps.release.outputs.upload_url }}
-      near_lake_version: ${{ env.NEAR_LAKE_VERSION }}
+  build-and-release:
+    runs-on: ubuntu-22.04-8core
+    if: >
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
+      (github.event_name == 'release' && github.event.action == 'created')
     steps:
-      - name: Get the release version from the tag
-        shell: bash
-        if: env.NEAR_LAKE_VERSION == ''
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Cache Cargo Registry and Build Output
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Install Rust toolchain
         run: |
-          # Apparently, this is the right way to get a tag name. Really?
-          #
-          # See: https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
-          echo "NEAR_LAKE_VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-          echo "version is: ${{ env.NEAR_LAKE_VERSION }}"
-      - name: Create GitHub release
-        id: release
-        uses: actions/create-release@v1
+          rustup update stable
+          rustup default stable
+
+      - name: Build release binary
+        run: |
+          cargo build --release --verbose
+          strip target/release/near-lake
+          cp target/release/near-lake near-lake
+
+      - name: Determine UPLOAD_URL
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            TAG_NAME=${GITHUB_REF#refs/tags/}
+            RELEASE_RESPONSE=$(curl -s -X GET -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "https://api.github.com/repos/${{ github.repository }}/releases/tags/$TAG_NAME")
+            UPLOAD_URL=$(echo "$RELEASE_RESPONSE" | jq -r .upload_url)
+            echo "UPLOAD_URL=$UPLOAD_URL" >> $GITHUB_ENV
+          else
+            echo "UPLOAD_URL=${{ github.event.release.upload_url }}" >> $GITHUB_ENV
+          fi
+
+      - name: Upload release asset
+        uses: actions/upload-release-asset@v1.0.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ env.NEAR_LAKE_VERSION }}
-          release_name: ${{ env.NEAR_LAKE_VERSION }}
-
-  build-release:
-    name: build-release
-    needs: ['create-release']
-    runs-on: ${{ matrix.os }}
-    env:
-      # For some builds, we use cross to test on 32-bit and big-endian
-      # systems.
-      CARGO: cargo
-      # When CARGO is set to CROSS, this is set to `--target matrix.target`.
-      TARGET_FLAGS: ""
-      # When CARGO is set to CROSS, TARGET_DIR includes matrix.target.
-      TARGET_DIR: ./target
-      # For some builds, we disable ledger support
-      FEATURES_FLAGS:
-      # Emit backtraces on panics.
-      RUST_BACKTRACE: 1
-      # Build static releases with PCRE2.
-      PCRE2_SYS_STATIC: 1
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-        - build: linux-x86_64
-          os: ubuntu-20.04
-          rust: stable
-          target: x86_64-unknown-linux-gnu
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 1
-
-    - name: Install Rust
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: ${{ matrix.rust }}
-        profile: minimal
-        override: true
-        target: ${{ matrix.target }}
-
-    - name: Use Cross
-      run: |
-        cargo install cross
-        echo "CARGO=cross" >> $GITHUB_ENV
-        echo "TARGET_FLAGS=--target ${{ matrix.target }}" >> $GITHUB_ENV
-        echo "TARGET_DIR=./target/${{ matrix.target }}" >> $GITHUB_ENV
-
-    - name: Build cross environment
-      shell: bash
-      run: |
-        if [ -d "./cross/${{ matrix.target }}" ]; then
-          docker build --tag "cross:${{ matrix.target }}" "./cross/${{ matrix.target }}"
-        fi
-
-    - name: Show command used for Cargo
-      run: |
-        echo "cargo command is: ${{ env.CARGO }}"
-        echo "target flag is: ${{ env.TARGET_FLAGS }}"
-        echo "target dir is: ${{ env.TARGET_DIR }}"
-
-    - name: Build release binary
-      run: ${{ env.CARGO }} build --verbose --release ${{ env.TARGET_FLAGS }} ${{ env.FEATURES_FLAGS }}
-
-    - name: Strip release binary (linux and macos)
-      run: |
-        strip "${{ env.TARGET_DIR }}/release/near-lake"
-        cp "${{ env.TARGET_DIR }}/release/near-lake" near-lake
-        echo "ASSET=near-lake" >> $GITHUB_ENV
-
-    - name: Upload release archive
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ needs.create-release.outputs.upload_url }}
-        asset_path: ${{ env.ASSET }}
-        asset_name: ${{ env.ASSET }}
-        asset_content_type: application/octet-stream
+          upload_url: ${{ env.UPLOAD_URL }}
+          asset_path: ./near-lake
+          asset_name: near-lake
+          asset_content_type: application/octet-stream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,13 +11,13 @@ on:
 jobs:
   build-and-release:
     runs-on: ubuntu-22.04
-    # Ensure the job runs only for the primary event that interests us.
     if: >
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
       (github.event_name == 'release' && github.event.action == 'created')
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+
       - name: Cache Cargo Registry and Build Output
         uses: actions/cache@v2
         with:
@@ -27,17 +27,18 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
-      - name: Set up Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+
+      - name: Install Rust toolchain
+        run: |
+          rustup update stable
+          rustup default stable
+
       - name: Build release binary
         run: |
           cargo build --release --verbose
           strip target/release/near-lake
           cp target/release/near-lake near-lake
+
       - name: Determine UPLOAD_URL
         run: |
           if [[ "${{ github.event_name }}" == "push" ]]; then
@@ -48,6 +49,7 @@ jobs:
           else
             echo "UPLOAD_URL=${{ github.event.release.upload_url }}" >> $GITHUB_ENV
           fi
+
       - name: Upload release asset
         uses: actions/upload-release-asset@v1.0.1
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,14 +10,14 @@ on:
 
 jobs:
   build-and-release:
-    runs-on: ubuntu-22.04-8core
+    runs-on: ubuntu-22.04
+    # Ensure the job runs only for the primary event that interests us.
     if: >
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
       (github.event_name == 'release' && github.event.action == 'created')
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-
       - name: Cache Cargo Registry and Build Output
         uses: actions/cache@v2
         with:
@@ -27,18 +27,17 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
-
-      - name: Install Rust toolchain
-        run: |
-          rustup update stable
-          rustup default stable
-
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
       - name: Build release binary
         run: |
           cargo build --release --verbose
           strip target/release/near-lake
           cp target/release/near-lake near-lake
-
       - name: Determine UPLOAD_URL
         run: |
           if [[ "${{ github.event_name }}" == "push" ]]; then
@@ -49,7 +48,6 @@ jobs:
           else
             echo "UPLOAD_URL=${{ github.event.release.upload_url }}" >> $GITHUB_ENV
           fi
-
       - name: Upload release asset
         uses: actions/upload-release-asset@v1.0.1
         env:


### PR DESCRIPTION
This should address the long-standing issue #75 along with some improvements (e.g. cache)

The nodes we currently use for running this indexer are Ubuntu 20.04, while the CI uses 22.04. I am working on upgrading the nodes separately so the binary produced by this workflow should work fine on the new nodes.