### PR TITLE
chore: Improve observability 

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[env]
+NEARCORE_VERSION = "1.37.1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3666,7 +3666,9 @@ dependencies = [
  "near-indexer",
  "near-indexer-primitives",
  "near-o11y",
+ "once_cell",
  "openssl-probe",
+ "rustc_version 0.4.0",
  "serde",
  "serde_json",
  "tokio",
@@ -4403,9 +4405,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.29"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 
+[build-dependencies]
+anyhow = "1.0.51"
+rustc_version = "0.4"
+
 [dependencies]
 actix = "0.13.0"
 anyhow = "1.0.51"
@@ -18,6 +22,7 @@ http = "0.2"
 humantime = "2.1.0"
 itertools = "0.10.0"
 openssl-probe = "0.1.5"
+once_cell = "1.19.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.55"
 tokio = { version = "1.1", features = ["sync", "time"] }
@@ -25,6 +30,7 @@ tokio-stream = { version = "0.1" }
 tracing = "0.1.34"
 tracing-subscriber = "0.2.4"
 
+# Please, update the supported nearcore version in .cargo/config.toml file
 near-indexer = { git = "https://github.com/near/nearcore", rev = "0f8e073b0be5c2df4d9382bd359edb4d1f88b632" }
 near-indexer-primitives = { git = "https://github.com/near/nearcore", rev = "0f8e073b0be5c2df4d9382bd359edb4d1f88b632" }
 near-client = { git = "https://github.com/near/nearcore", rev = "0f8e073b0be5c2df4d9382bd359edb4d1f88b632" }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,20 @@
+/// This build.rs script is used to generate build-time information and set environment variables for the build process.
+/// It retrieves the Rust compiler version and sets it as the `RUSTC_VERSION` environment variable.
+/// It also sets the `BUILD_VERSION` environment variable to the value of `NEARCORE_VERSION` defined in the project.
+/// Additionally, it prints messages to indicate which files should trigger a rebuild when changed.
+fn get_rustc_version() -> anyhow::Result<String> {
+    let version = rustc_version::version()?;
+    Ok(version.to_string())
+}
+
+fn main() -> anyhow::Result<()> {
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/index");
+
+    println!("cargo:rustc-env=BUILD_VERSION={}", env!("NEARCORE_VERSION"));
+
+    let rustc_version = get_rustc_version()?;
+    println!("cargo:rustc-env=RUSTC_VERSION={}", rustc_version);
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use tokio::sync::Mutex;
 use tracing_subscriber::EnvFilter;
 
 mod configs;
+mod metrics;
 mod utils;
 
 const INDEXER: &str = "near_lake";
@@ -48,6 +49,17 @@ fn main() {
                 "NEAR Lake v{} starting...",
                 env!("CARGO_PKG_VERSION")
             );
+
+            // This will set the near_lake_build_info metric
+            // e.g. near_lake_build_info{build="1.37.1",release="0.1.29",rustc_version="1.75.0"}
+            metrics::NODE_BUILD_INFO.reset();
+            metrics::NODE_BUILD_INFO
+                .with_label_values(&[
+                    env!("CARGO_PKG_VERSION"),
+                    env!("BUILD_VERSION"),
+                    env!("RUSTC_VERSION"),
+                ])
+                .inc();
 
             let system = actix::System::new();
             system.block_on(async move {
@@ -226,6 +238,7 @@ async fn handle_message(
     let mut stats_lock = stats.lock().await;
     stats_lock.block_heights_processing.remove(&block_height);
     stats_lock.blocks_processed_count += 1;
+    metrics::BLOCKS_DONE.inc();
     stats_lock.last_processed_block_height = block_height;
     drop(stats_lock);
     Ok(())
@@ -252,6 +265,7 @@ async fn put_object_or_retry(
                         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
                     }
                 }
+                metrics::RETRY_COUNT.inc();
                 tracing::warn!(
                     target: INDEXER,
                     "Failed to put {} to S3, retrying",

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,30 @@
+use near_o11y::metrics::*;
+use once_cell::sync::Lazy;
+
+pub static BLOCKS_DONE: Lazy<IntCounter> = Lazy::new(|| {
+    try_create_int_counter(
+        "near_lake_block_done_total",
+        "Total number of indexed blocks",
+    )
+    .unwrap()
+});
+
+pub static RETRY_COUNT: Lazy<IntCounter> = Lazy::new(|| {
+    try_create_int_counter(
+        "near_lake_block_retry_count_total",
+        "Total number of retries for storing indexing blocks to S3",
+    )
+    .unwrap()
+});
+
+// This metric is present in the near_o11y crate but it's not public
+// so we can't use it directly. We have to redefine it here.
+pub static NODE_BUILD_INFO: Lazy<IntCounterVec> = Lazy::new(|| {
+    try_create_int_counter_vec(
+        "near_lake_build_info",
+        "Metric whose labels indicate node’s version; see \
+             <https://www.robustperception.io/exposing-the-software-version-to-prometheus>.",
+        &["release", "build", "rustc_version"],
+    )
+    .unwrap()
+});


### PR DESCRIPTION
This PR aims to improve the observability of the node by adding metrics:

* `near_lake_block_retry_count_total` Total number of retries for storing indexing blocks to S3
* `near_lake_block_done_total` Total number of indexed blocks

The first can be used to determine whether the service was restarted (e.g., killed by OOM). The second can help determine whether the node is healthy and what the retry rate is.

Additionally, I have added `near_lake_build_info` similar to the existing `near_build_info`, but I cannot reuse that since it's private. It will expose the build info. Example:

```
near_lake_build_info{build="1.37.1",release="0.1.29",rustc_version="1.75.0"}
```