### PR TITLE
fix: newest AWS updates failing on localstack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.71 AS builder
+FROM rust:1.78 AS builder
 WORKDIR /tmp/
 
 # Copy from nearcore:

--- a/src/main.rs
+++ b/src/main.rs
@@ -243,13 +243,13 @@ async fn handle_message(
         client.clone(),
         bucket.clone(),
         block_json,
-        format!("{}/block.json", base_key).to_string(),
+        format!("{}/{}/block.json", bucket, base_key).to_string(),
     )
     .await;
 
     // Shards
     for shard in streamer_message.shards.iter() {
-        let key = format!("{}/shard_{}.json", base_key, shard.shard_id);
+        let key = format!("{}/{}/shard_{}.json", bucket, base_key, shard.shard_id);
         let shard_json =
             serde_json::to_value(shard).expect("Failed to serialize IndexerShard to JSON");
         put_object_or_retry(client.clone(), bucket.clone(), shard_json, key).await;
@@ -293,6 +293,7 @@ async fn put_object_or_retry(
                 metrics::RETRY_COUNT.inc();
                 tracing::warn!(
                     target: INDEXER,
+                    ?err,
                     "Failed to put {} to S3, retrying",
                     &filename
                 );


### PR DESCRIPTION
Unsure if this should be merged in or not. The latest AWS sdk dependency updates with node version 1.40 changes the way requests are being sent where localstack will interpret the first item in the path as the bucket since testing with localstack requires s3 in one of the prefixes for the domain name to have `virtual hosted`? So this change makes into a `path` based.

For more information, look at related issue in localstack: https://github.com/localstack/localstack/issues/9951

@khorolets not sure if this is working properly on the NEAR node side with actual AWS. Could also make this a parameter to change up the path for localstack testing
