### PR TITLE
chore:bump-new-version-to-2.2.0

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [env]
-NEARCORE_VERSION = "2.2.0-rc.1-d630c63"
+NEARCORE_VERSION = "2.2.0-7dbfa11"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.2.0
+
+* Upgrade Indexer Framework to be based on [nearcore 2.2.0](https://github.com/near/nearcore/releases/tag/2.2.0)
+
 ## 2.2.0-rc.1
 
 * Upgrade Indexer Framework to be based on [nearcore 2.2.0-rc.1](https://github.com/near/nearcore/releases/tag/2.2.0-rc.1)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3296,8 +3296,8 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "actix",
  "derive_more",
@@ -3316,8 +3316,8 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3326,16 +3326,16 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "lru 0.12.4",
 ]
 
 [[package]]
 name = "near-chain"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "actix",
  "assert_matches",
@@ -3381,8 +3381,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -3406,8 +3406,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "near-crypto",
  "near-primitives",
@@ -3419,8 +3419,8 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "actix",
  "borsh 1.5.1",
@@ -3452,8 +3452,8 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "near-chain-primitives",
  "near-primitives",
@@ -3461,8 +3461,8 @@ dependencies = [
 
 [[package]]
 name = "near-client"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3519,8 +3519,8 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "actix",
  "chrono",
@@ -3541,8 +3541,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -3552,8 +3552,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "blake2",
  "borsh 1.5.1",
@@ -3577,8 +3577,8 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -3597,8 +3597,8 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "borsh 1.5.1",
  "itertools 0.10.5",
@@ -3621,16 +3621,16 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "near-primitives-core",
 ]
 
 [[package]]
 name = "near-indexer"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "actix",
  "anyhow",
@@ -3657,8 +3657,8 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "near-primitives",
  "serde",
@@ -3667,8 +3667,8 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "actix",
  "actix-cors",
@@ -3699,8 +3699,8 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "actix-http",
  "awc",
@@ -3713,8 +3713,8 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -3730,7 +3730,7 @@ dependencies = [
 
 [[package]]
 name = "near-lake"
-version = "2.2.0-rc.1"
+version = "2.2.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -3759,8 +3759,8 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
@@ -3770,8 +3770,8 @@ dependencies = [
 
 [[package]]
 name = "near-network"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "actix",
  "anyhow",
@@ -3822,8 +3822,8 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "actix",
  "base64 0.21.7",
@@ -3848,8 +3848,8 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "borsh 1.5.1",
  "enum-map",
@@ -3865,8 +3865,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -3881,8 +3881,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "quote",
  "syn 2.0.72",
@@ -3890,8 +3890,8 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "borsh 1.5.1",
  "near-crypto",
@@ -3903,8 +3903,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -3946,8 +3946,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -3966,8 +3966,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "actix",
  "actix-cors",
@@ -3997,8 +3997,8 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-core"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "quote",
  "serde",
@@ -4007,8 +4007,8 @@ dependencies = [
 
 [[package]]
 name = "near-rpc-error-macro"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "near-rpc-error-core",
  "serde",
@@ -4017,13 +4017,13 @@ dependencies = [
 
 [[package]]
 name = "near-stdx"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 
 [[package]]
 name = "near-store"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4066,13 +4066,13 @@ dependencies = [
 
 [[package]]
 name = "near-structs-checker-core"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 
 [[package]]
 name = "near-structs-checker-lib"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "near-structs-checker-core",
  "near-structs-checker-macro",
@@ -4080,13 +4080,13 @@ dependencies = [
 
 [[package]]
 name = "near-structs-checker-macro"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 
 [[package]]
 name = "near-telemetry"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "actix",
  "awc",
@@ -4105,8 +4105,8 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "once_cell",
  "serde",
@@ -4116,8 +4116,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -4132,8 +4132,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -4153,8 +4153,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -4176,8 +4176,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "anyhow",
  "blst",
@@ -4231,8 +4231,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "indexmap 1.9.3",
  "num-traits",
@@ -4242,8 +4242,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "backtrace",
  "cc",
@@ -4263,8 +4263,8 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "anyhow",
  "near-primitives-core",
@@ -4274,8 +4274,8 @@ dependencies = [
 
 [[package]]
 name = "nearcore"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4364,8 +4364,8 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.2.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=d630c63d45bf2a98039ee15364af1717224e924a#d630c63d45bf2a98039ee15364af1717224e924a"
+version = "2.2.0"
+source = "git+https://github.com/near/nearcore?rev=7dbfa116bdab065ac417e85281a2e74bab6fc2ef#7dbfa116bdab065ac417e85281a2e74bab6fc2ef"
 dependencies = [
  "borsh 1.5.1",
  "near-crypto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-lake"
-version = "2.2.0-rc.1"
+version = "2.2.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 
@@ -29,7 +29,7 @@ tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 
 # Please, update the supported nearcore version in .cargo/config.toml file
-near-indexer = { git = "https://github.com/near/nearcore", rev = "d630c63d45bf2a98039ee15364af1717224e924a" }
-near-indexer-primitives = { git = "https://github.com/near/nearcore", rev = "d630c63d45bf2a98039ee15364af1717224e924a" }
-near-client = { git = "https://github.com/near/nearcore", rev = "d630c63d45bf2a98039ee15364af1717224e924a" }
-near-o11y = { git = "https://github.com/near/nearcore", rev = "d630c63d45bf2a98039ee15364af1717224e924a" }
+near-indexer = { git = "https://github.com/near/nearcore", rev = "7dbfa116bdab065ac417e85281a2e74bab6fc2ef" }
+near-indexer-primitives = { git = "https://github.com/near/nearcore", rev = "7dbfa116bdab065ac417e85281a2e74bab6fc2ef" }
+near-client = { git = "https://github.com/near/nearcore", rev = "7dbfa116bdab065ac417e85281a2e74bab6fc2ef" }
+near-o11y = { git = "https://github.com/near/nearcore", rev = "7dbfa116bdab065ac417e85281a2e74bab6fc2ef" }


### PR DESCRIPTION
* Upgrade Indexer Framework to be based on [nearcore 2.2.0](https://github.com/near/nearcore/releases/tag/2.2.0)