### PR TITLE
chore: bump-new-version-2.3.0

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [env]
-NEARCORE_VERSION = "2.3.0-rc.4-726cdba"
+NEARCORE_VERSION = "2.3.0-cf41c79"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.3.0
+
+* Upgrade Indexer Framework to be based on [nearcore 2.3.0](https://github.com/near/nearcore/releases/tag/2.3.0)
+
 ## 2.3.0-rc.4
 
 * Upgrade Indexer Framework to be based on [nearcore 2.3.0-rc.4](https://github.com/near/nearcore/releases/tag/2.3.0-rc.4)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3296,8 +3296,8 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "actix",
  "derive_more",
@@ -3316,8 +3316,8 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3326,16 +3326,16 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "lru 0.12.4",
 ]
 
 [[package]]
 name = "near-chain"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "actix",
  "assert_matches",
@@ -3383,8 +3383,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -3407,8 +3407,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "near-crypto",
  "near-primitives",
@@ -3420,8 +3420,8 @@ dependencies = [
 
 [[package]]
 name = "near-chunks"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "actix",
  "borsh 1.5.1",
@@ -3452,8 +3452,8 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "near-chain-primitives",
  "near-primitives",
@@ -3461,8 +3461,8 @@ dependencies = [
 
 [[package]]
 name = "near-client"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3519,8 +3519,8 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "actix",
  "chrono",
@@ -3541,8 +3541,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -3552,8 +3552,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "blake2",
  "borsh 1.5.1",
@@ -3577,8 +3577,8 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "anyhow",
  "near-chain-configs",
@@ -3596,8 +3596,8 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "borsh 1.5.1",
  "itertools 0.10.5",
@@ -3622,16 +3622,16 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "near-primitives-core",
 ]
 
 [[package]]
 name = "near-indexer"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "actix",
  "anyhow",
@@ -3657,8 +3657,8 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "near-primitives",
  "serde",
@@ -3667,8 +3667,8 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "actix",
  "actix-cors",
@@ -3697,8 +3697,8 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "actix-http",
  "awc",
@@ -3711,8 +3711,8 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -3728,7 +3728,7 @@ dependencies = [
 
 [[package]]
 name = "near-lake"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -3758,8 +3758,8 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
@@ -3769,8 +3769,8 @@ dependencies = [
 
 [[package]]
 name = "near-network"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "actix",
  "anyhow",
@@ -3821,8 +3821,8 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "actix",
  "base64 0.21.7",
@@ -3846,8 +3846,8 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "borsh 1.5.1",
  "enum-map",
@@ -3864,8 +3864,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "actix",
  "bitflags 1.3.2",
@@ -3879,8 +3879,8 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "quote",
  "syn 2.0.72",
@@ -3888,8 +3888,8 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "borsh 1.5.1",
  "near-crypto",
@@ -3900,8 +3900,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -3942,8 +3942,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -3962,8 +3962,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "actix",
  "actix-cors",
@@ -3993,13 +3993,13 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "near-schema-checker-core",
  "near-schema-checker-macro",
@@ -4007,18 +4007,18 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 
 [[package]]
 name = "near-stdx"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 
 [[package]]
 name = "near-store"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4061,8 +4061,8 @@ dependencies = [
 
 [[package]]
 name = "near-telemetry"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "actix",
  "awc",
@@ -4080,8 +4080,8 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "serde",
  "time",
@@ -4090,8 +4090,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "enumset",
  "finite-wasm",
@@ -4106,8 +4106,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "dynasm 2.0.0",
  "dynasmrt 2.0.0",
@@ -4126,8 +4126,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -4148,8 +4148,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "anyhow",
  "blst",
@@ -4204,8 +4204,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "indexmap 1.9.3",
  "num-traits",
@@ -4215,8 +4215,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "backtrace",
  "cc",
@@ -4236,8 +4236,8 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "anyhow",
  "near-primitives-core",
@@ -4246,8 +4246,8 @@ dependencies = [
 
 [[package]]
 name = "nearcore"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "actix",
  "actix-rt",
@@ -4335,8 +4335,8 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.3.0-rc.4"
-source = "git+https://github.com/near/nearcore?rev=726cdba11efc7f761dd84e8e542d2706f5dff24f#726cdba11efc7f761dd84e8e542d2706f5dff24f"
+version = "2.3.0"
+source = "git+https://github.com/near/nearcore?rev=cf41c79a83f2dbc5517c7dc1e51d864b24240c77#cf41c79a83f2dbc5517c7dc1e51d864b24240c77"
 dependencies = [
  "borsh 1.5.1",
  "near-crypto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-lake"
-version = "2.3.0-rc.4"
+version = "2.3.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 
@@ -29,8 +29,8 @@ tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 
 # Please, update the supported nearcore version in .cargo/config.toml file
-near-indexer = { git = "https://github.com/near/nearcore", rev = "726cdba11efc7f761dd84e8e542d2706f5dff24f" }
-near-indexer-primitives = { git = "https://github.com/near/nearcore", rev = "726cdba11efc7f761dd84e8e542d2706f5dff24f" }
-near-client = { git = "https://github.com/near/nearcore", rev = "726cdba11efc7f761dd84e8e542d2706f5dff24f" }
-near-config-utils = { git = "https://github.com/near/nearcore", rev = "726cdba11efc7f761dd84e8e542d2706f5dff24f" }
-near-o11y = { git = "https://github.com/near/nearcore", rev = "726cdba11efc7f761dd84e8e542d2706f5dff24f" }
+near-indexer = { git = "https://github.com/near/nearcore", rev = "cf41c79a83f2dbc5517c7dc1e51d864b24240c77" }
+near-indexer-primitives = { git = "https://github.com/near/nearcore", rev = "cf41c79a83f2dbc5517c7dc1e51d864b24240c77" }
+near-client = { git = "https://github.com/near/nearcore", rev = "cf41c79a83f2dbc5517c7dc1e51d864b24240c77" }
+near-config-utils = { git = "https://github.com/near/nearcore", rev = "cf41c79a83f2dbc5517c7dc1e51d864b24240c77" }
+near-o11y = { git = "https://github.com/near/nearcore", rev = "cf41c79a83f2dbc5517c7dc1e51d864b24240c77" }


### PR DESCRIPTION
* Upgrade Indexer Framework to be based on [nearcore 2.3.0](https://github.com/near/nearcore/releases/tag/2.3.0)